### PR TITLE
Implement proper ProxyPingEvent for 1.7.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,5 +43,11 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.4</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
@@ -1,0 +1,86 @@
+package net.md_5.bungee.api;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents the standard list data returned by opening a server in the
+ * Minecraft client server list, or hitting it with a packet 0xFE. (copied from
+ * BungeeCord 1.7.2; representing the new ping method)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewServerPing
+{
+
+    private Protocol version;
+
+    @Data
+    @AllArgsConstructor
+    public static class Protocol
+    {
+
+        private String name;
+        private int protocol;
+    }
+    private Players players;
+
+    @Data
+    @AllArgsConstructor
+    public static class Players
+    {
+
+        private int max;
+        private int online;
+    }
+    private String description;
+    private String favicon;
+
+    /**
+     * Converts this object to a {@link ServerPing}, as used by 1.6.4 clients.
+     *
+     * @return A {@link ServerPing} object with all data contained in this
+     * object. Changes are not written back.
+     */
+    public ServerPing toServerPing()
+    {
+        return new ServerPing( (byte) this.version.getProtocol(), //It will take a while until the protocol version strikes 127
+                this.version.getName(),
+                this.description,
+                this.players.getOnline(),
+                this.players.getMax() );
+    }
+
+    /**
+     * Converts this object to a {@link JsonObject}, as accepted by the
+     * Minecrfat client in the 1.7.2 ping process and as seen in
+     * http://wiki.vg/Server_List_Ping#1.7 .
+     *
+     * @return A {@link JsonObject} containing this object's data.
+     */
+    public JsonObject toJson()
+    {
+        JsonObject json = new JsonObject();
+        JsonObject jsonVersion = new JsonObject();
+        JsonObject jsonPlayers = new JsonObject();
+        jsonVersion.add( "name", new JsonPrimitive( version.getName() ) );
+        jsonVersion.add( "protocol", new JsonPrimitive( version.getProtocol() ) );
+        jsonPlayers.add( "max", new JsonPrimitive( players.getMax() ) );
+        jsonPlayers.add( "online", new JsonPrimitive( players.getOnline() ) );
+        jsonPlayers.add( "sample", new JsonArray() ); // empty array
+        json.add( "version", jsonVersion );
+        json.add( "players", jsonPlayers );
+        json.add( "description", new JsonPrimitive( description.replaceAll( "\\\\n", "\n" ) ) );
+        if ( favicon != null )
+        {
+            json.add( "favicon", new JsonPrimitive( favicon ) );
+        }
+
+        return json;
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -30,4 +30,19 @@ public class ServerPing
      * Max amount of players the server will allow.
      */
     private final int maxPlayers;
+
+    /**
+     * Converts this object to a {@link NewServerPing}, as used by 1.7.2
+     * clients.
+     *
+     * @return A {@link NewServerPing} object with all data contained in this
+     * object. Changes are not written back.
+     */
+    public NewServerPing toNewServerPing()
+    {
+        return new NewServerPing(
+                new NewServerPing.Protocol( gameVersion, protocolVersion ),
+                new NewServerPing.Players( maxPlayers, currentPlayers ),
+                motd, null );
+    }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import net.md_5.bungee.api.NewServerPing;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Event;
@@ -12,7 +13,7 @@ import net.md_5.bungee.api.plugin.Event;
  * Called when the proxy is pinged with packet 0xFE from the server list.
  */
 @Data
-@AllArgsConstructor
+@AllArgsConstructor //kept for completeness
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class ProxyPingEvent extends Event
@@ -23,7 +24,32 @@ public class ProxyPingEvent extends Event
      */
     private final PendingConnection connection;
     /**
-     * The data to respond with.
+     * The data to respond with. (for 1.6.4 pings; filled in at 1.7.2 for
+     * conveinience)
      */
     private ServerPing response;
+    /**
+     * 1.7.2 response, if this event was caused by 1.7.2 ping.
+     */
+    private NewServerPing newResponse;
+    /**
+     * Specifies if this ping event was caused by a 1.7.2 client.
+     */
+    private boolean isNewProtocol;
+
+    public ProxyPingEvent(final PendingConnection connection, final ServerPing response)
+    {
+        this.connection = connection;
+        this.response = response;
+        this.newResponse = null;
+        this.isNewProtocol = false;
+    }
+
+    public ProxyPingEvent(final PendingConnection connection, final NewServerPing newResponse)
+    {
+        this.connection = connection;
+        this.response = newResponse.toServerPing();
+        this.newResponse = newResponse;
+        this.isNewProtocol = true;
+    }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
@@ -52,4 +52,13 @@ public class ProxyPingEvent extends Event
         this.newResponse = newResponse;
         this.isNewProtocol = true;
     }
+
+    public void setResponse(final ServerPing resp)
+    {
+        this.response = resp;
+        if ( this.isNewProtocol )
+        {
+            this.newResponse = resp.toNewServerPing();
+        }
+    }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -1,9 +1,6 @@
 package net.md_5.bungee.connection;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
@@ -18,9 +15,15 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.md_5.bungee.*;
+import net.md_5.bungee.BungeeCord;
+import net.md_5.bungee.EncryptionUtil;
+import net.md_5.bungee.PacketConstants;
+import net.md_5.bungee.UserConnection;
+import net.md_5.bungee.Util;
+import net.md_5.bungee.api.AbstractReconnectHandler;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.NewServerPing;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ListenerInfo;
@@ -28,20 +31,37 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.LoginEvent;
+import net.md_5.bungee.api.event.PlayerHandshakeEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.ProxyPingEvent;
 import net.md_5.bungee.http.HttpClient;
-import net.md_5.bungee.netty.*;
+import net.md_5.bungee.netty.ChannelWrapper;
+import net.md_5.bungee.netty.HandlerBoss;
+import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.netty.decoders.CipherDecoder;
-import net.md_5.bungee.netty.encoders.CipherEncoder;
 import net.md_5.bungee.netty.decoders.PacketDecoder;
+import net.md_5.bungee.netty.encoders.CipherEncoder;
 import net.md_5.bungee.protocol.Forge;
 import net.md_5.bungee.protocol.MinecraftInput;
 import net.md_5.bungee.protocol.Vanilla;
-import net.md_5.bungee.protocol.packet.*;
-import net.md_5.bungee.api.AbstractReconnectHandler;
-import net.md_5.bungee.api.event.PlayerHandshakeEvent;
-import net.md_5.bungee.protocol.packet.protocolhack.*;
+import net.md_5.bungee.protocol.packet.DefinedPacket;
+import net.md_5.bungee.protocol.packet.Packet1Login;
+import net.md_5.bungee.protocol.packet.Packet2Handshake;
+import net.md_5.bungee.protocol.packet.PacketCDClientStatus;
+import net.md_5.bungee.protocol.packet.PacketFAPluginMessage;
+import net.md_5.bungee.protocol.packet.PacketFCEncryptionResponse;
+import net.md_5.bungee.protocol.packet.PacketFDEncryptionRequest;
+import net.md_5.bungee.protocol.packet.PacketFEPing;
+import net.md_5.bungee.protocol.packet.PacketFFKick;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketEncryptionRequest;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketEncryptionResponse;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketHandshake;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketLoginStart;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketLoginSuccess;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketPing;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketPingRequest;
+import net.md_5.bungee.protocol.packet.protocolhack.PacketPingResponse;
 
 @RequiredArgsConstructor
 public class InitialHandler extends PacketHandler implements PendingConnection
@@ -177,22 +197,46 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(PacketPingRequest pingRequest)
     {
-        JsonObject result = new JsonObject();
-        JsonObject version = new JsonObject();
-        version.add( "name", new JsonPrimitive( "1.7.2" ) );
-        version.add( "protocol", new JsonPrimitive( 4 ) );
-        JsonObject players = new JsonObject();
-        players.add( "max", new JsonPrimitive( listener.getMaxPlayers() ) );
-        players.add( "online", new JsonPrimitive( bungee.getOnlineCount() ) );
-        players.add( "sample", new JsonArray() ); // empty array
-        result.add( "version", version );
-        result.add( "players", players );
-        result.add( "description", new JsonPrimitive( listener.getMultilineMotd().replaceAll( "\\\\n", "\n" ) ) );
-        String favicon = bungee.getFavicon();
-        if ( favicon != null ) {
-            result.add( "favicon", new JsonPrimitive( favicon ) );
+        ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
+        final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
+        final Callback<NewServerPing> pingBack = new Callback<NewServerPing>()
+        {
+            @Override
+            public void done(NewServerPing result, Throwable error)
+            {
+                if ( error != null )
+                {
+                    result = new NewServerPing( new NewServerPing.Protocol( "-1", -1 ),
+                            new NewServerPing.Players( -1, -1 ),
+                            "Error pinging remote server: " + Util.exception( error ),
+                            null );
+                }
+
+                result = bungee.getPluginManager().callEvent( new ProxyPingEvent( InitialHandler.this, result ) ).getNewResponse();
+
+                unsafe().sendPacket( new PacketPingResponse( result.toJson().toString() ) );
+            }
+        };
+
+        if ( forced != null && listener.isPingPassthrough() )
+        {
+            forced.ping( new Callback<ServerPing>() //TODO: interfaces?
+            {
+                @Override
+                public void done(ServerPing result, Throwable error)
+                {
+                    pingBack.done( result.toNewServerPing(), error );
+                }
+            } );
+        } else
+        {
+            pingBack.done( new NewServerPing(
+                    new NewServerPing.Protocol( "1.7.2", 4 ), //TODO: There must be a better solution to this
+                    new NewServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount() ),
+                    motd,
+                    bungee.getFavicon() ),
+                    null );
         }
-        unsafe().sendPacket( new PacketPingResponse( result.toString() ) );
     }
 
     @Override


### PR DESCRIPTION
This pull request adds a **proper ProxyPingEvent for 1.7.2 pings** by adding a new class NewServerPing, which is used to represent a 1.7.2 equivalent of ServerPing. I have moved the Json logic there for readability. 
I have also modified the ProxyPingEvent to provide a boolean stating if the new protocol is used and providing a NewServerPing. To maintain compatibility with 1.6.4 Bungee plugins, the NewServerPing is converted to the 1.6.4 ServerPing in the constructor if it's a 1.7.2 event. If it's a 1.6.4 event, only the ServerPing is created. If a 1.6.4 plugin sets the response for a 1.7.2 event, the NewServerPing is updated.

Should be 100% compatible with 1.6.4 plugins!

This adds a google json dependency to api, adds a new Class NewServerPing to represent 1.7.2 ping responses, adds a method to ServerPing to convert into a NewServerPing object, moves json creation form InitialHandler to NewServerPing, adds event compatibility for 1.7.2 pings. 

I have tested it, BungeeCord compiles and runs, my test plugin worked just fine and as intended. 

I have not provided any more material as this repo does not contain a CONTRIBUTUING.md at the moment, but can adapt. (Especially names - It might be more accurate to name NewServerPing 172ServerPing, but this looks ugly :D)

Thanks for considering it.
