### PR TITLE
Add in support to set the summary array of players in 1.7 json pings

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
@@ -96,7 +96,7 @@ public class NewServerPing
 
                 JsonObject jsonPlayerSample = new JsonObject();
                 jsonPlayerSample.add( "name", new JsonPrimitive( playerInfo.getName() ) );
-                jsonPlayerSample.add( "id", new JsonPrimitive( "aaaa" ) ); //In the future the real uuid can be put here.
+                jsonPlayerSample.add( "id", new JsonPrimitive( playerInfo.getId() ) );
                 jsonPlayerInfo.add(jsonPlayerSample);
 
             }

--- a/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.api;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -37,7 +38,20 @@ public class NewServerPing
 
         private int max;
         private int online;
+
     }
+
+    @Data
+    @AllArgsConstructor
+    public static class PlayerInfo
+    {
+
+        private String name;
+        private String id;
+    }
+
+    private List<PlayerInfo> sample;
+
     private String description;
     private String favicon;
 
@@ -72,10 +86,33 @@ public class NewServerPing
         jsonVersion.add( "protocol", new JsonPrimitive( version.getProtocol() ) );
         jsonPlayers.add( "max", new JsonPrimitive( players.getMax() ) );
         jsonPlayers.add( "online", new JsonPrimitive( players.getOnline() ) );
-        jsonPlayers.add( "sample", new JsonArray() ); // empty array
+
+        if ( sample != null )
+        {
+
+            JsonArray jsonPlayerInfo = new JsonArray();
+
+            for ( PlayerInfo playerInfo : sample ) {
+
+                JsonObject jsonPlayerSample = new JsonObject();
+                jsonPlayerSample.add( "name", new JsonPrimitive( playerInfo.getName() ) );
+                jsonPlayerSample.add( "id", new JsonPrimitive( "aaaa" ) ); //In the future the real uuid can be put here.
+                jsonPlayerInfo.add(jsonPlayerSample);
+
+            }
+
+            jsonPlayers.add( "sample", jsonPlayerInfo );
+
+        }
+        else
+        {
+            jsonPlayers.add( "sample", new JsonArray() );
+        }
+
         json.add( "version", jsonVersion );
         json.add( "players", jsonPlayers );
         json.add( "description", new JsonPrimitive( description.replaceAll( "\\\\n", "\n" ) ) );
+
         if ( favicon != null )
         {
             json.add( "favicon", new JsonPrimitive( favicon ) );

--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.api;
 
-import java.util.List;
 import lombok.Data;
 
 /**

--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api;
 
+import java.util.List;
 import lombok.Data;
 
 /**
@@ -43,6 +44,6 @@ public class ServerPing
         return new NewServerPing(
                 new NewServerPing.Protocol( gameVersion, protocolVersion ),
                 new NewServerPing.Players( maxPlayers, currentPlayers ),
-                motd, null );
+                null, motd, null );
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -210,7 +210,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 if ( error != null )
                 {
                     result = new NewServerPing( new NewServerPing.Protocol( "-1", -1 ),
-                            new NewServerPing.Players( -1, -1 ),
+                            new NewServerPing.Players( -1, -1 ), null,
                             "Error pinging remote server: " + Util.exception( error ),
                             null );
                 }
@@ -235,7 +235,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         {
             pingBack.done( new NewServerPing(
                     new NewServerPing.Protocol( "1.7.2", 4 ), //TODO: There must be a better solution to this
-                    new NewServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount() ), motd, bungee.getFavicon() ), null );
+                    new NewServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount() ), null, motd, bungee.getFavicon() ), null );
         }
         BungeeCord.getInstance().getConnectionThrottle().unthrottle( getAddress().getAddress() );
     }


### PR DESCRIPTION
Example on usage (similar to how you do it in upstream bungee 1.7.2):  https://gist.github.com/mccore/7595129
