### PR TITLE
Removed @NoArgsConstructor of NewServerPing

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/NewServerPing.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Represents the standard list data returned by opening a server in the
@@ -13,7 +12,6 @@ import lombok.NoArgsConstructor;
  * BungeeCord 1.7.2; representing the new ping method)
  */
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 public class NewServerPing
 {


### PR DESCRIPTION
Because it was never intended to be there and led to wrong usage of the API (#4). Also, it could cause some errors if plugins construct an empty instance and pass that.
