### PR TITLE
Rewrite sounds that were renamed in the 1.7 client

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/packetrewriter/SoundEffectRewriter.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/packetrewriter/SoundEffectRewriter.java
@@ -16,6 +16,18 @@ public class SoundEffectRewriter extends PacketRewriter
     public void rewriteServerToClient(ByteBuf in, ByteBuf out)
     {
         String soundname = Var.readString( in, false );
+        if (soundname.equals("damage.hit"))
+        {
+            soundname = "game.neutral.hurt";
+        }
+        else if (soundname.equals("damage.fallbig"))
+        {
+            soundname = "game.neutral.hurt.fall.big";
+        }
+        else if (soundname.equals("damage.fallsmall"))
+        {
+            soundname = "game.neutral.hurt.fall.small";
+        }
         Var.writeString( soundname, out, true );
         out.writeBytes( in.readBytes( in.readableBytes() ) );
     }


### PR DESCRIPTION
Reference: http://git.io/pQ5uAQ
There are more sounds there that changed but they seem to play fine on my client. The three I changed were the most obvious ones and are pretty annoying to not have on a pvp server.
