### PR TITLE
Use 1.7 Kick packets in InitialHandler where needed

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/protocolhack/PacketKick.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/protocolhack/PacketKick.java
@@ -1,0 +1,37 @@
+package net.md_5.bungee.protocol.packet.protocolhack;
+
+import io.netty.buffer.ByteBuf;
+import net.md_5.bungee.protocol.packet.AbstractPacketHandler;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class PacketKick extends Defined172Packet
+{
+    private String reason;
+
+    public PacketKick(String reason)
+    {
+        super( 0x00 );
+        this.reason = reason;
+    }
+
+    @Override
+    public void read(ByteBuf buf)
+    {
+    }
+
+    @Override
+    public void write(ByteBuf buf)
+    {
+        writeString( "{text:\"" + reason + "\"}", buf, true );
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+    }
+}


### PR DESCRIPTION
Ok so after a git mishap I have deleted and re pushed the branch. This is tested with online mode on both 1.6 and 1.7 with cancelling the login event. Below text copied from failed PR:

1.7 clients that are kicked in the initial stage are sent packets with 1.6 kick body, causing strange client messages rather than the ban reasons I wanted it to display.

I've attempted to add a 1.7 disconnect method to initial handler that sends a 1.7 kick packet to the client in all the 1.7 sections of the code. I'm unsure if this was the correct way to fix this but it seems to be working for cancelled login events for me.
