### PR TITLE
Add PreLoginEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -37,4 +37,18 @@ public interface PendingConnection extends Connection
      * @return the accepting listener
      */
     ListenerInfo getListener();
+    
+    /**
+     * Get this connection's online mode.
+     *
+     * @return the online mode
+     */
+    boolean isOnlineMode();
+    
+    /**
+     * Set this connection's online mode.
+     * 
+     * @param onlineMode 
+     */
+    void setOnlineMode(boolean onlineMode);
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -14,7 +14,8 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable {
+public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable
+{
 
     /**
      * Cancelled state.

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -1,0 +1,37 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.connection.PendingConnection;
+import net.md_5.bungee.api.plugin.Cancellable;
+
+/**
+ * Event called to represent a player first making their presence and username
+ * known.
+ */
+@Data
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable {
+
+    /**
+     * Cancelled state.
+     */
+    private boolean cancelled;
+    /**
+     * Message to use when kicking if this event is canceled.
+     */
+    private String cancelReason;
+    /**
+     * Connection attempting to login.
+     */
+    private final PendingConnection connection;
+
+    public PreLoginEvent(PendingConnection connection, Callback<PreLoginEvent> done)
+    {
+        super( done );
+        this.connection = connection;
+    }
+}


### PR DESCRIPTION
This PR adds `PreLoginEvent` from 1.7 BungeeCord to provide compatibility for new plugins. 
This implements #21 by @tf101-wizard.

**Note that these changes are untested** - I will pull this to master once I get confirmation that it works as intended for both protocols.
Artifacts for testing are located at http://ci.nowak-at.net/job/public~TUD_Bungee_PR/
